### PR TITLE
Fixes strong reference on AuthenticationSelectionViewController

### DIFF
--- a/src/Extensibility/AuthenticationSelectionViewController.swift
+++ b/src/Extensibility/AuthenticationSelectionViewController.swift
@@ -22,7 +22,7 @@ import IdsvrHaapiUIKit
  */
 class AuthenticationSelectionViewController: UIViewController, HaapiUIViewController {
     
-    var haapiFlowViewControllerDelegate: HaapiFlowViewControllerDelegate?
+    weak var haapiFlowViewControllerDelegate: HaapiFlowViewControllerDelegate?
     var uiStylableThemeDelegate: UIStylableThemeDelegate?
     var model: SelectorModel
  


### PR DESCRIPTION
When dismissing `AuthenticationSelectionViewController,` the presented ViewController cannot be deallocated, and the `HaapiManager` cannot be closed when closing the view. Therefore, an error occurs when restarting the HaapiFlow.

By adding the `weak` keyword, the presented ViewController can be deallocated, and the `HaapiManager` can be closed when the view is closed.