### PR TITLE
Minor HAAPI refinements

### DIFF
--- a/config/docker-template.xml
+++ b/config/docker-template.xml
@@ -80,8 +80,8 @@
                                 <attestation>
                                 <disable-attestation-validation>true</disable-attestation-validation>
                                 <ios>
-                                    <app-id>$APPLE_BUNDLE_ID</app-id>
-                                    <ios-policy>ios-dev-policy</ios-policy>
+                                    <app-id>$APPLE_TEAM_ID.$APPLE_BUNDLE_ID</app-id>
+                                    <ios-policy>ios-policy</ios-policy>
                                 </ios>
                                 </attestation>
                             </client>
@@ -94,7 +94,7 @@
     <facilities xmlns="https://curity.se/ns/conf/base">
         <client-attestation>
             <ios-policy xmlns="https://curity.se/ns/conf/client-attestation">
-                <id>ios-dev-policy</id>
+                <id>ios-policy</id>
                 <mode>non-production</mode>
             </ios-policy>
         </client-attestation>

--- a/haapidemo.xcodeproj/project.pbxproj
+++ b/haapidemo.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		282A70EE2A5D694E000AE4FD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 282A70ED2A5D694E000AE4FD /* Assets.xcassets */; };
 		282A70F82A5D6A81000AE4FD /* DemoAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282A70F72A5D6A81000AE4FD /* DemoAppDelegate.swift */; };
 		282A70FD2A5D7664000AE4FD /* TrustAllCertsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282A70FC2A5D7664000AE4FD /* TrustAllCertsDelegate.swift */; };
+		2852E9652DDF3899001D9A52 /* IdsvrHaapiUIKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2852E9642DDF3899001D9A52 /* IdsvrHaapiUIKit */; };
 		287C37C62A66E08600385838 /* CustomTheme.plist in Resources */ = {isa = PBXBuildFile; fileRef = 287C37C52A66E08600385838 /* CustomTheme.plist */; };
 		287EE0C92A6A9A0F00B628F1 /* AuthenticatedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287EE0C82A6A9A0F00B628F1 /* AuthenticatedView.swift */; };
 		287EE0CB2A6AAE3500B628F1 /* ExpanderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287EE0CA2A6AAE3500B628F1 /* ExpanderView.swift */; };
@@ -23,7 +24,6 @@
 		287EE0D32A6AE6FF00B628F1 /* AccessTokenModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287EE0D22A6AE6FF00B628F1 /* AccessTokenModel.swift */; };
 		287EE0D52A6AE8FE00B628F1 /* UserInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287EE0D42A6AE8FE00B628F1 /* UserInfoView.swift */; };
 		287EE0D82A6AED8B00B628F1 /* AccessTokenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287EE0D72A6AED8B00B628F1 /* AccessTokenView.swift */; };
-		289B58552AFD05A700366FBA /* IdsvrHaapiUIKit in Frameworks */ = {isa = PBXBuildFile; productRef = 289B58542AFD05A700366FBA /* IdsvrHaapiUIKit */; };
 		289FF4102DAFCE48005ABF2B /* ErrorReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289FF40F2DAFCE3F005ABF2B /* ErrorReader.swift */; };
 		28C9FD6B2A65278800902F08 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C9FD6A2A65278800902F08 /* MainView.swift */; };
 		28C9FD6F2A65315400902F08 /* OAuthStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C9FD6E2A65315400902F08 /* OAuthStateModel.swift */; };
@@ -90,7 +90,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				289B58552AFD05A700366FBA /* IdsvrHaapiUIKit in Frameworks */,
+				2852E9652DDF3899001D9A52 /* IdsvrHaapiUIKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -208,7 +208,7 @@
 			);
 			name = haapidemo;
 			packageProductDependencies = (
-				289B58542AFD05A700366FBA /* IdsvrHaapiUIKit */,
+				2852E9642DDF3899001D9A52 /* IdsvrHaapiUIKit */,
 			);
 			productName = haapidemo;
 			productReference = 282A70E62A5D694C000AE4FD /* haapidemo.app */;
@@ -239,7 +239,7 @@
 			);
 			mainGroup = 282A70DD2A5D694C000AE4FD;
 			packageReferences = (
-				289B58532AFD05A700366FBA /* XCRemoteSwiftPackageReference "ios-idsvr-haapi-ui-kit-dist" */,
+				2852E9632DDF3899001D9A52 /* XCRemoteSwiftPackageReference "ios-idsvr-haapi-ui-kit-dist" */,
 			);
 			productRefGroup = 282A70E72A5D694C000AE4FD /* Products */;
 			projectDirPath = "";
@@ -509,20 +509,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		289B58532AFD05A700366FBA /* XCRemoteSwiftPackageReference "ios-idsvr-haapi-ui-kit-dist" */ = {
+		2852E9632DDF3899001D9A52 /* XCRemoteSwiftPackageReference "ios-idsvr-haapi-ui-kit-dist" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/curityio/ios-idsvr-haapi-ui-kit-dist";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.5.0;
+				minimumVersion = 4.6.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		289B58542AFD05A700366FBA /* IdsvrHaapiUIKit */ = {
+		2852E9642DDF3899001D9A52 /* IdsvrHaapiUIKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 289B58532AFD05A700366FBA /* XCRemoteSwiftPackageReference "ios-idsvr-haapi-ui-kit-dist" */;
+			package = 2852E9632DDF3899001D9A52 /* XCRemoteSwiftPackageReference "ios-idsvr-haapi-ui-kit-dist" */;
 			productName = IdsvrHaapiUIKit;
 		};
 /* End XCSwiftPackageProductDependency section */


### PR DESCRIPTION
- Update to latest SDK with a fix for a missing cursor (previously the cursor defaulted to white on a white background and the SDK update fixes this)

- Rename the ios-policy so that it is not just for development. You can attach a device to Xcode and enable attestation against the OAuth client. For that to work, the appID needed prefixing with a TeamID.